### PR TITLE
Pledge to gauge a threadable iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,62 @@ SYNOPSIS
 ```raku
 use v6.d;
 use Gauge;
-# How fast can (1..10) be generated? Take an estimate of how many iterations
-# can be sunk in 1 second every 20 seconds:
-.say for Gauge(-> --> Nil { sink 1..10 }).poll(1).throttle(19);
+
+#|[ Jury-rigged benchmark that keys it/s counts of an evaluated code block. ]
+sub MAIN(
+    **@code,
+    #|[ The number of threads to dedicate to benchmarking. ]
+    UInt:D :j(:$jobs) = $*KERNEL.cpu-cores.pred,
+    #|[ The duration in seconds over which timestamps will be aggregated. ]
+    Real:D :p(:$period) = 1,
+    #|[ The cooldown in seconds performed between each individual benchmark. ]
+    Real:D :c(:$cooldown) = (try 2 / 3 * $jobs * $period orelse 2 / 3 * $*KERNEL.cpu-cores.pred),
+    #|[ Whether or not ANSI 24-bit SGR escape sequences should be suppressed.
+        These highlight blocks of it/s counts opneing with newfound maximums. ]
+    Bool:D :m(:$mono) = False,
+--> Nil) {
+    use MONKEY-SEE-NO-EVAL;
+    map $mono ?? &mono !! &poly,
+        Gauge(EVAL Qa[-> { @code.join() }])
+            .poll($period)
+            .pledge($jobs)
+            .throttle($cooldown);
+}
+#=[ Benchmark threads are run once an iteration of any existing threads has
+    been exhausted. This is staggered by the cooldown, and by default, allows
+    for multiple benchmarks to be taken with a brief overlap of threaded work,
+    reducing the time needed to aggregate results while keeping low overhead. ]
+
+sub poly(Int:D $next --> Empty) {
+    my constant @mark = «\e[48;5;198m \e[48;5;202m \e[48;5;178m \e[48;5;41m \e[48;5;25m \e[48;5;129m»;
+    state $mark is default(-1);
+    state $peak is default(0);
+
+    my $jump := $peak < $next;
+    $mark += $jump;
+    $mark %= @mark;
+    $peak max= $next;
+
+    my $note = @mark[$mark];
+    $note ~= $jump ?? '⊛' !! '∗';
+    $note ~= " \e[m";
+    $note ~= $next;
+
+    put $note
+}
+
+sub mono(Int:D $next --> Empty) {
+    state $peak is default(0);
+
+    my $jump := $peak < $next;
+    $peak max= $next;
+
+    my $note = $jump ?? '⊛' !! '∗';
+    $note ~= ' ';
+    $note ~= $next;
+
+    put $note
+}
 ```
 
 DESCRIPTION
@@ -23,19 +76,7 @@ DESCRIPTION
 class Gauge is Seq { ... }
 ```
 
-`Gauge`, in general, wraps a lazy, non-deterministic, time-oriented iterator. At its base, it attempts to measure durations of calls to a block with as little overhead as possible in order to avoid unnecessary influence over results. This does not make for a proper benchmark on its own, but may provide raw input for such a utility.
-
-ATTRIBUTES
-==========
-
-$!gc
-----
-
-```raku
-has Bool:D $.gc is default(so $*VM.name eq <moar jvm>.any);
-```
-
-`$!gc` toggles garbage collection before intensive iterations in general, i.e. those of `poll` currently. By default, this will be `True` on MoarVM and the JVM. If set to `False`, iterations are very likely to be skewed by any interruption due to GC (if available).
+`Gauge`, in general, provides an interface for a collection of temporal, lazy, non-deterministic iterators. At its base, it attempts to measure durations of calls to a block with as little overhead as possible in order to avoid unnecessary influence over results. This can stack operations mapping its iterator until it decays to a `Seq` via `Iterable` or the `iterator` itself.
 
 METHODS
 =======
@@ -44,12 +85,10 @@ CALL-ME
 -------
 
 ```raku
-method CALL-ME(::?CLASS:_: Block:D $block, *%attrinit --> ::?CLASS:D)
+method CALL-ME(::?CLASS:_: Block:D $block --> ::?CLASS:D)
 ```
 
 Produces a new `Gauge` sequence of native `uint64` durations of a call to the given block. Measurements of each duration are **not** monotonic, thus leap seconds and hardware errors will skew results.
-
-If `%attrinit` is provided, a clone will be produced with it to allow for attributes to be set.
 
 poll
 ----
@@ -58,7 +97,7 @@ poll
 method poll(::?CLASS:D: Real:D $seconds --> ::?CLASS:D)
 ```
 
-Returns a new `Gauge` sequence that produces an `Int:D` count of iterations of the former totalling a duration of `$seconds`. This will take longer than the given argument to complete due to the overhead of iteration.
+Returns a new `Gauge` sequence that produces an `Int:D` count of iterations of the former totalling a duration of `$seconds`. This will take longer than the given argument to complete due to the overhead of iteration, which may be measured by `Gauge` itself in combination with `head`.
 
 throttle
 --------
@@ -67,7 +106,20 @@ throttle
 method throttle(::?CLASS:D: Real:D $seconds --> ::?CLASS:D)
 ```
 
-Returns a new `Gauge` sequence that will sleep `$seconds` between iterations of the former.
+Returns a new `Gauge` sequence that will sleep `$seconds` between iterations of its former. If a `poll` is applied later, this will incorporate the time waited into the time it takes to complete an iteration, but not any steps in between required to caculated. The total time throttled is allowed to exceed any poll applied to a `Gauge`, but never by any more than one iteration.
+
+pledge
+------
+
+```raku
+method pledge(::?CLASS:D: UInt:D $length --> ::?CLASS:D)
+```
+
+Returns a new `Gauge` sequence that, across an array of threads of breadth `$length`, pledges that a form of iteration will be continuously invoked across a threaded repetition of this iterator's component iterators in the process. When an empty length is given, this will not change the iteration.
+
+When a length of `1` is given, this will produce a `covenant` wrapping the iterator. This is a thread that upon receiving a query to perform an iteration, will produce its result, then go ahead and perform another iteration while waiting for the next query. This means switching from `skip` to `head` may perform an extra `skip` whose result is discarded while waiting for `head`. Such a thread will finish in a sink context, but is allowed to wait until the end of a program after decaying to another `Seq` when it doesn't play nice.
+
+When a length of `2` or more is given, a *contract* wrapping this number of covenants will be formed. This carries a particular cycle followed to accomodate any throttling performed beforehand. A thread must be spawned in order to work, but any prior threads may complete an iteration during this timespan, and will be waited on in reverse as each covenant is run in its original ordering.
 
 AUTHOR
 ======
@@ -77,7 +129,7 @@ Ben Davies (Kaiepi)
 COPYRIGHT AND LICENSE
 =====================
 
-Copyright 2022 Ben Davies
+Copyright 2023 Ben Davies
 
 This library is free software; you can redistribute it and/or modify it under the Artistic License 2.0.
 

--- a/README.pod6
+++ b/README.pod6
@@ -11,9 +11,62 @@ Gauge - Iterative polling
 =begin code :lang<raku>
 use v6.d;
 use Gauge;
-# How fast can (1..10) be generated? Take an estimate of how many iterations
-# can be sunk in 1 second every 20 seconds:
-.say for Gauge(-> --> Nil { sink 1..10 }).poll(1).throttle(19);
+
+#|[ Jury-rigged benchmark that keys it/s counts of an evaluated code block. ]
+sub MAIN(
+    **@code,
+    #|[ The number of threads to dedicate to benchmarking. ]
+    UInt:D :j(:$jobs) = $*KERNEL.cpu-cores.pred,
+    #|[ The duration in seconds over which timestamps will be aggregated. ]
+    Real:D :p(:$period) = 1,
+    #|[ The cooldown in seconds performed between each individual benchmark. ]
+    Real:D :c(:$cooldown) = (try 2 / 3 * $jobs * $period orelse 2 / 3 * $*KERNEL.cpu-cores.pred),
+    #|[ Whether or not ANSI 24-bit SGR escape sequences should be suppressed.
+        These highlight blocks of it/s counts opneing with newfound maximums. ]
+    Bool:D :m(:$mono) = False,
+--> Nil) {
+    use MONKEY-SEE-NO-EVAL;
+    map $mono ?? &mono !! &poly,
+        Gauge(EVAL Qa[-> { @code.join() }])
+            .poll($period)
+            .pledge($jobs)
+            .throttle($cooldown);
+}
+#=[ Benchmark threads are run once an iteration of any existing threads has
+    been exhausted. This is staggered by the cooldown, and by default, allows
+    for multiple benchmarks to be taken with a brief overlap of threaded work,
+    reducing the time needed to aggregate results while keeping low overhead. ]
+
+sub poly(Int:D $next --> Empty) {
+    my constant @mark = «\e[48;5;198m \e[48;5;202m \e[48;5;178m \e[48;5;41m \e[48;5;25m \e[48;5;129m»;
+    state $mark is default(-1);
+    state $peak is default(0);
+
+    my $jump := $peak < $next;
+    $mark += $jump;
+    $mark %= @mark;
+    $peak max= $next;
+
+    my $note = @mark[$mark];
+    $note ~= $jump ?? '⊛' !! '∗';
+    $note ~= " \e[m";
+    $note ~= $next;
+
+    put $note
+}
+
+sub mono(Int:D $next --> Empty) {
+    state $peak is default(0);
+
+    my $jump := $peak < $next;
+    $peak max= $next;
+
+    my $note = $jump ?? '⊛' !! '∗';
+    $note ~= ' ';
+    $note ~= $next;
+
+    put $note
+}
 =end code
 
 =head1 DESCRIPTION
@@ -21,37 +74,22 @@ use Gauge;
 =for code :lang<raku>
 class Gauge is Seq { ... }
 
-C<Gauge>, in general, wraps a lazy, non-deterministic, time-oriented iterator.
-At its base, it attempts to measure durations of calls to a block with as
-little overhead as possible in order to avoid unnecessary influence over
-results. This does not make for a proper benchmark on its own, but may provide
-raw input for such a utility.
-
-=head1 ATTRIBUTES
-
-=head2 $!gc
-
-=for code :lang<raku>
-has Bool:D $.gc is default(so $*VM.name eq <moar jvm>.any);
-
-C<$!gc> toggles garbage collection before intensive iterations in general,
-i.e. those of C<poll> currently. By default, this will be C<True> on MoarVM and
-the JVM. If set to C<False>, iterations are very likely to be skewed by any
-interruption due to GC (if available).
+C<Gauge>, in general, provides an interface for a collection of temporal, lazy,
+non-deterministic iterators. At its base, it attempts to measure durations of
+calls to a block with as little overhead as possible in order to avoid
+unnecessary influence over results. This can stack operations mapping its
+iterator until it decays to a C<Seq> via C<Iterable> or the C<iterator> itself.
 
 =head1 METHODS
 
 =head2 CALL-ME
 
 =for code :lang<raku>
-method CALL-ME(::?CLASS:_: Block:D $block, *%attrinit --> ::?CLASS:D)
+method CALL-ME(::?CLASS:_: Block:D $block --> ::?CLASS:D)
 
 Produces a new C<Gauge> sequence of native C<uint64> durations of a call to the
 given block. Measurements of each duration are B<not> monotonic, thus leap
 seconds and hardware errors will skew results.
-
-If C<%attrinit> is provided, a clone will be produced with it to allow for
-attributes to be set.
 
 =head2 poll
 
@@ -60,7 +98,8 @@ method poll(::?CLASS:D: Real:D $seconds --> ::?CLASS:D)
 
 Returns a new C<Gauge> sequence that produces an C<Int:D> count of iterations
 of the former totalling a duration of C<$seconds>. This will take longer than
-the given argument to complete due to the overhead of iteration.
+the given argument to complete due to the overhead of iteration, which may be
+measured by C<Gauge> itself in combination with C<head>.
 
 =head2 throttle
 
@@ -68,7 +107,35 @@ the given argument to complete due to the overhead of iteration.
 method throttle(::?CLASS:D: Real:D $seconds --> ::?CLASS:D)
 
 Returns a new C<Gauge> sequence that will sleep C<$seconds> between iterations
-of the former.
+of its former. If a C<poll> is applied later, this will incorporate the time
+waited into the time it takes to complete an iteration, but not any steps in
+between required to caculated. The total time throttled is allowed to exceed
+any poll applied to a C<Gauge>, but never by any more than one iteration.
+
+=head2 pledge
+
+=for code :lang<raku>
+method pledge(::?CLASS:D: UInt:D $length --> ::?CLASS:D)
+
+Returns a new C<Gauge> sequence that, across an array of threads of breadth
+C<$length>, pledges that a form of iteration will be continuously invoked
+across a threaded repetition of this iterator's component iterators in the
+process. When an empty length is given, this will not change the iteration.
+
+When a length of C<1> is given, this will produce a C<covenant> wrapping the
+iterator. This is a thread that upon receiving a query to perform an iteration,
+will produce its result, then go ahead and perform another iteration while
+waiting for the next query. This means switching from C<skip> to C<head> may
+perform an extra C<skip> whose result is discarded while waiting for C<head>.
+Such a thread will finish in a sink context, but is allowed to wait until the
+end of a program after decaying to another C<Seq> when it doesn't play nice.
+
+When a length of C<2> or more is given, a I<contract> wrapping this number of
+covenants will be formed. This carries a particular cycle followed to
+accomodate any throttling performed beforehand. A thread must be spawned in
+order to work, but any prior threads may complete an iteration during this
+timespan, and will be waited on in reverse as each covenant is run in its
+original ordering.
 
 =head1 AUTHOR
 
@@ -76,7 +143,7 @@ Ben Davies (Kaiepi)
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 2022 Ben Davies
+Copyright 2023 Ben Davies
 
 This library is free software; you can redistribute it and/or modify it under the Artistic License 2.0.
 

--- a/lib/Gauge.rakumod
+++ b/lib/Gauge.rakumod
@@ -40,7 +40,7 @@ class It does Iterator {
         nqp::getcodeobj($!block)
     }
 
-    method pull-one(::?CLASS:_: --> uint64) {
+    method pull-one(::?CLASS:D: --> uint64) {
         # XXX: A monotonic solution via Inline::Perl5 takes too long to take
         # the time, slashing the number of iterations that can be counted. A
         # NativeCall solution is apt to have the similar problems. Using &now
@@ -70,8 +70,6 @@ role Poller does Iterator {
     }
 
     method block(::?CLASS:D: --> Block:D) { $!it.block }
-
-    method gc(::?CLASS:D: --> Bool:D) { ... }
 }
 
 #|[ Counts iterations over a nanosecond duration with minimal overhead, but as
@@ -79,7 +77,7 @@ role Poller does Iterator {
 class Poller::Raw does Poller {
     method gc(::?CLASS:_: --> False) { }
 
-    method pull-one(::?CLASS:_:) {
+    method pull-one(::?CLASS:D:) {
         use nqp;
         nqp::stmts(
           (my $ns is default(0)),
@@ -94,7 +92,7 @@ class Poller::Raw does Poller {
 class Poller::Collected does Poller {
     method gc(::?CLASS:_: --> True) { }
 
-    method pull-one(::?CLASS:_:) {
+    method pull-one(::?CLASS:D:) {
         use nqp;
         nqp::stmts(
           (my $ns is default(0)),
@@ -122,7 +120,7 @@ class Throttler does Iterator {
 
     method gc(::?CLASS:D: --> Bool:D) { $!it.gc }
 
-    method pull-one(::?CLASS:_:) {
+    method pull-one(::?CLASS:D:) {
         use nqp;
         nqp::stmts(
           nqp::if(

--- a/t/02-basic.rakutest
+++ b/t/02-basic.rakutest
@@ -2,7 +2,7 @@ use v6.d;
 use Test;
 use Gauge;
 
-plan 12;
+plan 18;
 
 my constant SECOND = 1_000_000_000;
 
@@ -24,9 +24,23 @@ my constant SECOND = 1_000_000_000;
 }
 
 {
-    my $it = Gauge(-> { (+*...*) }).throttle(1).iterator;
+    my $it = Gauge(-> { (**...**) }).throttle(1).iterator;
     ok $it ~~ Gauge::Iterator, 'Gauge::Throttler is a type of Gauge::Iterator...';
     isa-ok $it.pull-one, Int, '...which transparently wraps its iterator...';
     cmp-ok Gauge(-> { $it.pull-one }).head, &[>=], SECOND, '...performing a cooldown between iterations...';
+    cmp-ok Gauge(-> { $it.skip-one }).head, &[>=], SECOND, '...even when skipped';
+}
+
+{
+    my $it = Gauge(-> { (｢｣...｢｣) }).throttle(1).poll(0.5).iterator;
+    cmp-ok $it.pull-one, &[==], 1, 'Gauge::Poller polls before the cooldown of a Gauge::Throttler...';
+    cmp-ok Gauge(-> { $it.pull-one }).head, &[>=], SECOND, '...while preserving it between iterations...';
+    cmp-ok Gauge(-> { $it.skip-one }).head, &[>=], SECOND, '...even when skipped';
+}
+
+{
+    my $it = Gauge(-> { ($++,++$) }).poll(0.5).throttle(0.5).iterator;
+    cmp-ok $it.pull-one, &[>], 1, 'Gauge::Throttler does not throttle the poll of a Gauge::Poller...';
+    cmp-ok Gauge(-> { $it.pull-one }).head, &[>=], SECOND, '...but the iteration performing a poll...';
     cmp-ok Gauge(-> { $it.skip-one }).head, &[>=], SECOND, '...even when skipped';
 }

--- a/t/02-basic.rakutest
+++ b/t/02-basic.rakutest
@@ -2,18 +2,15 @@ use v6.d;
 use Test;
 use Gauge;
 
-plan 13;
+plan 11;
 
 {
     my $calls = 0;
     my &block = -> --> True { $calls++ };
     my $it = Gauge::It.new: :&block;
     ok $it ~~ Gauge::Iterator, 'Gauge::It is a type of Gauge::Iterator...';
-    lives-ok {
-        isa-ok $it.pull-one, Int, '...which produces an integer duration...';
-        ok $calls, '...given a call to the block...';
-        cmp-ok $it.block, &[eqv], &block, '...which is equivalent to the original...';
-    }, '...despite any container it may carry';
+    isa-ok $it.pull-one, Int, '...which produces an integer duration...';
+    ok $calls, '...given a call to the block';
 };
 
 {

--- a/t/02-basic.rakutest
+++ b/t/02-basic.rakutest
@@ -2,7 +2,7 @@ use v6.d;
 use Test;
 use Gauge;
 
-plan 17;
+plan 13;
 
 {
     my $calls = 0;
@@ -16,9 +16,9 @@ plan 17;
     }, '...despite any container it may carry';
 };
 
-for Gauge::Poller::Raw, Gauge::Poller::Collected -> \Poller {
-    my $it = Poller.new: :1seconds, it => Gauge::It.new: :block({ sleep 0.5 }), :gc(Poller.gc);
-    ok $it ~~ Gauge::Iterator, Poller.^name ~ ' is a type of Gauge::Iterator...';
+{
+    my $it = Gauge::Poller.new: :1seconds, it => Gauge::It.new: :block({ sleep 0.5 });
+    ok $it ~~ Gauge::Iterator, 'Gauge::Poller is a type of Gauge::Iterator...';
     isa-ok $it.pull-one, Int, '...which produces an integer count...';
     my $begin := now;
     my $count := $it.pull-one;

--- a/t/02-basic.rakutest
+++ b/t/02-basic.rakutest
@@ -2,7 +2,7 @@ use v6.d;
 use Test;
 use Gauge;
 
-plan 18;
+plan 21;
 
 my constant SECOND = 1_000_000_000;
 
@@ -43,4 +43,27 @@ my constant SECOND = 1_000_000_000;
     cmp-ok $it.pull-one, &[>], 1, 'Gauge::Throttler does not throttle the poll of a Gauge::Poller...';
     cmp-ok Gauge(-> { $it.pull-one }).head, &[>=], SECOND, '...but the iteration performing a poll...';
     cmp-ok Gauge(-> { $it.skip-one }).head, &[>=], SECOND, '...even when skipped';
+}
+
+{
+    my $calls = $*THREAD.id;
+    my $it = Gauge(-> { $calls ⚛= $*THREAD.id }).pledge(0).iterator;
+    $it.skip-one;
+    cmp-ok ⚛$calls, &[==], $*THREAD.id, 'a void pledge does not a thread make';
+}
+
+if $*KERNEL.cpu-cores < 1 {
+    skip 'Gauge::Covenant needs threads!';
+} else {
+    my $calls = $*THREAD.id;
+    my $it = Gauge(-> { $calls ⚛= $*THREAD.id }).pledge(1).iterator;
+    $it.skip-one;
+    cmp-ok ⚛$calls, &[!=], $*THREAD.id, 'Gauge::Covenant iterates from another thread';
+}
+
+if $*KERNEL.cpu-cores < 2 {
+    skip 'Gauge::Contract needs threads!';
+} else {
+    my $it = Gauge(-> { (0+*∘*+0) }).throttle(1).poll(1).pledge(2).iterator;
+    cmp-ok $it.pull-one, &[>], $it.pull-one, 'Gauge::Contract can time in parallel following its cycle';
 }

--- a/t/02-basic.rakutest
+++ b/t/02-basic.rakutest
@@ -2,45 +2,31 @@ use v6.d;
 use Test;
 use Gauge;
 
-plan 11;
+plan 12;
+
+my constant SECOND = 1_000_000_000;
 
 {
     my $calls = 0;
-    my &block = -> --> True { $calls++ };
-    my $it = Gauge::It.new: :&block;
+    my $it = Gauge(-> { $calls++ }).iterator;
     ok $it ~~ Gauge::Iterator, 'Gauge::It is a type of Gauge::Iterator...';
     isa-ok $it.pull-one, Int, '...which produces an integer duration...';
     ok $calls, '...given a call to the block';
 };
 
 {
-    my $it = Gauge::Poller.new: :1seconds, it => Gauge::It.new: :block({ sleep 0.5 });
+    my $it = Gauge(-> { sleep 0.5 }).poll(1).iterator;
     ok $it ~~ Gauge::Iterator, 'Gauge::Poller is a type of Gauge::Iterator...';
-    isa-ok $it.pull-one, Int, '...which produces an integer count...';
-    my $begin := now;
-    my $count := $it.pull-one;
-    my $end := now;
-    ok 1 <= $count <= 2, '...which is reasonable...';
-    cmp-ok $end - $begin, &[>=], 1, '...taking at least its duration to complete';
+    isa-ok (my $count = $it.pull-one), Int, '...which produces an integer count...';
+    cmp-ok $count, &[~~], (1..2), '...which is reasonable...';
+    cmp-ok Gauge(-> { $it.pull-one }).head, &[>=], SECOND, '...taking at least its duration to complete...';
+    cmp-ok Gauge(-> { $it.skip-one }).head, &[>=], SECOND, '...even when skipped';
 }
 
 {
-    my $it = Gauge::Throttler.new: :1seconds, it => Gauge::It.new: :block({ (+*...*) });
+    my $it = Gauge(-> { (+*...*) }).throttle(1).iterator;
     ok $it ~~ Gauge::Iterator, 'Gauge::Throttler is a type of Gauge::Iterator...';
-    my @stamps[2];
-    my $begin := now;
-    my $stamp := $it.pull-one;
-    @stamps[0] := now - $begin;
-    isa-ok $stamp, Int, '...which transparently wraps its iterator...';
-    $begin := now;
-    $it.pull-one;
-    @stamps[1] := now - $begin;
-    cmp-ok @stamps[1], &[>], @stamps[0], '...performing a cooldown between iterations';
-}
-
-{
-    my $begin := now;
-    Gauge(-> { <0> <=> <0> }).throttle(1).skip(2);
-    my $end := now;
-    cmp-ok $end - $begin, &[>=], 1, 'skipping gauged iterations produces their side effects anyway';
+    isa-ok $it.pull-one, Int, '...which transparently wraps its iterator...';
+    cmp-ok Gauge(-> { $it.pull-one }).head, &[>=], SECOND, '...performing a cooldown between iterations...';
+    cmp-ok Gauge(-> { $it.skip-one }).head, &[>=], SECOND, '...even when skipped';
 }

--- a/t/02-basic.rakutest
+++ b/t/02-basic.rakutest
@@ -17,7 +17,7 @@ plan 17;
 };
 
 for Gauge::Poller::Raw, Gauge::Poller::Collected -> \Poller {
-    my $it = Poller.new: :1seconds, it => Gauge::It.new: :block({ sleep 0.5 });
+    my $it = Poller.new: :1seconds, it => Gauge::It.new: :block({ sleep 0.5 }), :gc(Poller.gc);
     ok $it ~~ Gauge::Iterator, Poller.^name ~ ' is a type of Gauge::Iterator...';
     isa-ok $it.pull-one, Int, '...which produces an integer count...';
     my $begin := now;


### PR DESCRIPTION
This PR is geared to introducing the `pledge` operation towards its tail. This takes a cyclic algorithm that allows for a characteristic overlap of iterations to occur. A complete benchmark case is included in `README.md`, as there theoretically would only be one combination of operations that could distribute load evenly, as would be the typical application of the library. Weirder applications of the library, e.g. threads stressing all iterators at once, are included in the tests.